### PR TITLE
Add playground machines sub-command to labctl for listing machines in a playground

### DIFF
--- a/cmd/playground/machines.go
+++ b/cmd/playground/machines.go
@@ -1,0 +1,41 @@
+package playground
+
+import (
+	"context"
+	"fmt"
+	"text/tabwriter"
+	"github.com/spf13/cobra"
+	"github.com/iximiuz/labctl/internal/labcli"
+)
+
+func newMachinesCommand(cli labcli.CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "machines [Playground ID]",
+		Short: `List machines of a specific playground by Playground ID`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			playgroundID := args[0]
+			return labcli.WrapStatusError(runListMachines(cmd.Context(), cli, playgroundID))
+		},
+	}
+
+	return cmd
+}
+
+func runListMachines(ctx context.Context, cli labcli.CLI, playgroundID string) error {
+	play, err := cli.Client().GetPlay(ctx, playgroundID)
+	if err != nil {
+		return fmt.Errorf("couldn't find playground with ID %s: %w", playgroundID, err)
+	}
+
+	writer := tabwriter.NewWriter(cli.OutputStream(), 0, 4, 2, ' ', 0)
+	defer writer.Flush()
+
+	fmt.Fprintln(writer, "MACHINE NAME")
+
+	for _, machine := range play.Machines {
+		fmt.Fprintln(writer, machine.Name)
+	}
+
+	return nil
+}

--- a/cmd/playground/playground.go
+++ b/cmd/playground/playground.go
@@ -17,6 +17,7 @@ func NewCommand(cli labcli.CLI) *cobra.Command {
 		newListCommand(cli),
 		newStartCommand(cli),
 		newStopCommand(cli),
+		newMachinesCommand(cli),
 	)
 
 	return cmd


### PR DESCRIPTION
### **Summary**: 
This PR introduces a new sub-command `machines` under the `playground` command in the `labctl` CLI tool. This command allows users to list the machines associated with a specific playground by providing the Playground ID.

### **Changes Made:**

- Created a new sub-command `machines` under the `playground` command.
- Implemented the logic to fetch and display machines using the Playground ID.
- Utilized the existing `GetPlay` method in the API client to retrieve playground details.

### **Usage**: 
To list the machines for a specific playground, use the following command:
```bash
labctl playground machines <Playground ID>
```

### **Examples**
1. To list machines for a playground with ID 67103cf80fd263a6eea588d2, run:
```bash
labctl playground machines 67103cf80fd263a6eea588d2
```
This will output:
```bash
MACHINE NAME
machine1
machine2
machine3
```
2. If the specified Playground ID does not exist, an error message will be displayed:
```bash
Couldn't find playground with ID 99999: request failed with status 404: {"error":"Play not found."}.
```