### PR TITLE
Adding filter by status flag to Challenges

### DIFF
--- a/cmd/challenge/catalog.go
+++ b/cmd/challenge/catalog.go
@@ -13,13 +13,14 @@ import (
 
 type catalogOptions struct {
 	category string
+	status   string
 }
 
 func newCatalogCommand(cli labcli.CLI) *cobra.Command {
 	var opts catalogOptions
 
 	cmd := &cobra.Command{
-		Use:     "catalog [--category <linux|containers|kubernetes|...>]",
+		Use:     "catalog [--category <linux|containers|kubernetes|...>] --status <todo|attempted|solved>",
 		Aliases: []string{"catalog"},
 		Short:   "List challenges from the catalog, optionally filtered by category",
 		Args:    cobra.NoArgs,
@@ -35,6 +36,13 @@ func newCatalogCommand(cli labcli.CLI) *cobra.Command {
 		"category",
 		"",
 		`Category to filter by - one of linux, containers, kubernetes, ... (an empty string means all)`,
+	)
+
+	flags.StringVar(
+		&opts.status,
+		"status",
+		"",
+		`status to filter by - one of todo, attempted, solved ... (empty means all))`,
 	)
 
 	return cmd
@@ -54,6 +62,7 @@ type catalogItem struct {
 func runCatalogChallenges(ctx context.Context, cli labcli.CLI, opts *catalogOptions) error {
 	challenges, err := cli.Client().ListChallenges(ctx, &api.ListChallengesOptions{
 		Category: opts.category,
+		Status:   opts.status,
 	})
 	if err != nil {
 		return fmt.Errorf("cannot list challenges: %w", err)

--- a/cmd/challenge/catalog.go
+++ b/cmd/challenge/catalog.go
@@ -35,14 +35,14 @@ func newCatalogCommand(cli labcli.CLI) *cobra.Command {
 		&opts.category,
 		"category",
 		[]string{},
-		`Category to filter by - one or multiple categories like linux, containers, kubernetes, ... (an empty string means all)`,
+		`Category to filter by - one or multiple categories like linux, containers, kubernetes`,
 	)
 
 	flags.StringSliceVar(
 		&opts.status,
 		"status",
 		[]string{},
-		`status to filter by - one or multiple status like todo, attempted, solved ... (empty means all))`,
+		`status to filter by - one or multiple status like todo, attempted, solved)`,
 	)
 
 	return cmd

--- a/cmd/challenge/catalog.go
+++ b/cmd/challenge/catalog.go
@@ -12,15 +12,15 @@ import (
 )
 
 type catalogOptions struct {
-	category string
-	status   string
+	category []string
+	status   []string
 }
 
 func newCatalogCommand(cli labcli.CLI) *cobra.Command {
 	var opts catalogOptions
 
 	cmd := &cobra.Command{
-		Use:     "catalog [--category <linux|containers|kubernetes|...>] --status <todo|attempted|solved>",
+		Use:     "catalog [--category <linux|containers|kubernetes|...>] --status <todo|attempted|solved|...>",
 		Aliases: []string{"catalog"},
 		Short:   "List challenges from the catalog, optionally filtered by category",
 		Args:    cobra.NoArgs,
@@ -31,18 +31,18 @@ func newCatalogCommand(cli labcli.CLI) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.StringVar(
+	flags.StringSliceVar(
 		&opts.category,
 		"category",
-		"",
-		`Category to filter by - one of linux, containers, kubernetes, ... (an empty string means all)`,
+		[]string{},
+		`Category to filter by - one or multiple categories like linux, containers, kubernetes, ... (an empty string means all)`,
 	)
 
-	flags.StringVar(
+	flags.StringSliceVar(
 		&opts.status,
 		"status",
-		"",
-		`status to filter by - one of todo, attempted, solved ... (empty means all))`,
+		[]string{},
+		`status to filter by - one or multiple status like todo, attempted, solved ... (empty means all))`,
 	)
 
 	return cmd

--- a/internal/api/challenges.go
+++ b/internal/api/challenges.go
@@ -110,6 +110,7 @@ func (c *Client) GetChallenge(ctx context.Context, name string) (*Challenge, err
 
 type ListChallengesOptions struct {
 	Category string
+	Status   string
 }
 
 func (c *Client) ListChallenges(ctx context.Context, opts *ListChallengesOptions) ([]*Challenge, error) {
@@ -117,6 +118,9 @@ func (c *Client) ListChallenges(ctx context.Context, opts *ListChallengesOptions
 	query := url.Values{}
 	if opts.Category != "" {
 		query.Set("category", opts.Category)
+	}
+	if opts.Status != "" {
+		query.Set("status", opts.Status)
 	}
 	return challenges, c.GetInto(ctx, "/challenges", query, nil, &challenges)
 }

--- a/internal/api/challenges.go
+++ b/internal/api/challenges.go
@@ -116,15 +116,13 @@ type ListChallengesOptions struct {
 func (c *Client) ListChallenges(ctx context.Context, opts *ListChallengesOptions) ([]*Challenge, error) {
 	var challenges []*Challenge
 	query := url.Values{}
-	if opts.Category != nil {
-		for _, category := range opts.Category {
-			query.Add("category",category)
-		}
+	
+	for _, category := range opts.Category {
+		query.Add("category", category)
 	}
-	if opts.Status != nil {
-		for _, status := range opts.Status {
-			query.Add("status",status)
-		}
+
+	for _, status := range opts.Status {
+		query.Add("status", status)
 	}
 
 	return challenges, c.GetInto(ctx, "/challenges", query, nil, &challenges)

--- a/internal/api/challenges.go
+++ b/internal/api/challenges.go
@@ -109,19 +109,24 @@ func (c *Client) GetChallenge(ctx context.Context, name string) (*Challenge, err
 }
 
 type ListChallengesOptions struct {
-	Category string
-	Status   string
+	Category []string
+	Status   []string
 }
 
 func (c *Client) ListChallenges(ctx context.Context, opts *ListChallengesOptions) ([]*Challenge, error) {
 	var challenges []*Challenge
 	query := url.Values{}
-	if opts.Category != "" {
-		query.Set("category", opts.Category)
+	if opts.Category != nil {
+		for _, category := range opts.Category {
+			query.Add("category",category)
+		}
 	}
-	if opts.Status != "" {
-		query.Set("status", opts.Status)
+	if opts.Status != nil {
+		for _, status := range opts.Status {
+			query.Add("status",status)
+		}
 	}
+
 	return challenges, c.GetInto(ctx, "/challenges", query, nil, &challenges)
 }
 


### PR DESCRIPTION
## Issues
* Unable to list challenges from labctl based on `status`, like if it was attempted or solved by the user or still a todo.
* Unable to filter on multiple categories.

## What does this PR do?
* Adding a `--status` flag to `labctl challenge catalog` , values are `todo`,`attempted`,`solved`
* Using combination of categories or status.

## More
* Status can be clubbed together with existing flag viz `category`
* Multiple categories can be specified like
   * ./labctl challenge catalog  --category linux,containers
   * ./labctl challenge catalog  --category linux,containers --status attempted

## Examples
```
hgupta@Harshils-MacBook-Pro labctl % ./labctl challenge catalog --status solved --category linux
- name: run-multiple-containers-in-one-cgroup
  title: Limit CPU and Memory Usage of a Docker Compose Application
  description: |
    Run a multi-container Docker Compose application limiting its total CPU and memory usage without specifying the individual container's limits.
  categories:
  - containers
  - linux
  tags:
  - docker
  - docker-compose
  - cgroups
  - systemd
  url: https://labs.iximiuz.com/challenges/run-multiple-containers-in-one-cgroup
  attempted: 54
  completed: 23
- name: linux-network-namespace
  title: Create a Linux Network Namespace
  description: |
    Learn how to create fully isolated virtual network environment using Linux network namespaces.
  categories:
  - linux
  - containers
  - networking
  tags:
  - netns
  - nsenter
  - unshare
  - ip
  url: https://labs.iximiuz.com/challenges/linux-network-namespace
  attempted: 424
  completed: 293
```

