### PR TITLE
Always print ssh-proxy connection information

### DIFF
--- a/cmd/sshproxy/sshproxy.go
+++ b/cmd/sshproxy/sshproxy.go
@@ -193,7 +193,7 @@ func RunSSHProxy(ctx context.Context, cli labcli.CLI, opts *Options) error {
 		cli.PrintErr("Unsupported IDE (skipping IDE connection): %q\n", opts.IDE)
 	}
 
-	if opts.IDE != "" && !opts.Quiet {
+	if !opts.Quiet {
 		cli.PrintAux("SSH proxy is running on %s\n", localPort)
 		cli.PrintAux(
 			"\n# Connect from the terminal:\nssh -i %s ssh://%s@%s:%s\n",


### PR DESCRIPTION
In order to make use of the ssh-proxy sub command, the connection information needs to be printed, as otherwise it is not possible to know the random port. Before this fix, the information was only ever printed, if the `--ide` option was present. This is confusing to users, as the docs for the `--ide` option only mention a hand full of supported IDEs. Instead, the connection information is now always printed, unless the quiet settings has been provided.