### PR TITLE
Fix playground tabs

### DIFF
--- a/api/playgrounds.go
+++ b/api/playgrounds.go
@@ -84,10 +84,10 @@ type PlaygroundMachine struct {
 }
 
 type PlaygroundTab struct {
-	ID          string `yaml:"id" json:"id"`
+	ID          string `yaml:"id,omitempty" json:"id,omitempty"`
 	Kind        string `yaml:"kind" json:"kind"`
 	Name        string `yaml:"name" json:"name"`
-	Machine     string `yaml:"machine" json:"machine"`
+	Machine     string `yaml:"machine,omitempty" json:"machine,omitempty"`
 	Number      int    `yaml:"number,omitempty" json:"number,omitempty"`
 	Tls         bool   `yaml:"tls,omitempty" json:"tls,omitempty"`
 	HostRewrite string `yaml:"hostRewrite,omitempty" json:"hostRewrite,omitempty"`

--- a/api/playgrounds.go
+++ b/api/playgrounds.go
@@ -92,6 +92,7 @@ type PlaygroundTab struct {
 	Tls         bool   `yaml:"tls,omitempty" json:"tls,omitempty"`
 	HostRewrite string `yaml:"hostRewrite,omitempty" json:"hostRewrite,omitempty"`
 	PathRewrite string `yaml:"pathRewrite,omitempty" json:"pathRewrite,omitempty"`
+	URL         string `yaml:"url,omitempty" json:"url,omitempty"`
 }
 
 type InitCondition struct {


### PR DESCRIPTION
This PR fixes web-page tabs by adding an URL field to the playground tab type.

It also makes a few fields omitted that are optional.