### PR TITLE
fix: argv duplication happening on android termux

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,9 @@ type configOverrides struct {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == os.Args[0] {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+	}
 	stdin, stdout, stderr := term.StdStreams()
 	cli := labcli.NewCLI(
 		stdin, stdout, stderr,


### PR DESCRIPTION
Updated main.go with a condition to check if argv[1] is a duplicate of argv[0]

This happened on my instance on an Android tablet running termux. I had no issues setting it up but on running labctl it returned this error:
~ $ labctl
Error: unknown command "/data/data/com.termux/files/home/.iximiuz/labctl/bin/labctl" for "labctl"
Run 'labctl --help' for usage.

So I looked into it and it turns out there was some weird things going on with termux, I've summarized the gist of it here with the help of AI:
**Why was it only Android/Termux?**
It's a combination of three things colliding:
**1. Android's linker behaviour**
Android uses its own dynamic linker (/system/bin/linker64) instead of the standard glibc ld-linux. When the kernel executes an ELF binary, it actually runs the interpreter (linker) and passes the binary path as an argument to it. On standard Linux this is transparent — glibc's linker strips it before main() sees anything. Android's linker doesn't clean this up the same way.
**2. Go's runtime on Android**
Go does its own low-level os.Args initialisation by reading directly from the process's memory/aux vectors rather than relying on the C runtime to hand it a clean argv. On standard Linux this works perfectly. On Android, the Go runtime picks up the raw argv including the extra path that linker64 injected, and surfaces it as os.Args[1].
**3. Termux specifically**
If labctl were running inside a proper Android app sandbox or ADB shell, the environment is set up differently. Termux is unusual — it's a terminal emulator running in Android userspace without root, so it inherits Android's linker quirks without the usual Android app framework smoothing things over.