### PR TITLE
feat: ignore backup files in file watcher

### DIFF
--- a/cmd/content/push.go
+++ b/cmd/content/push.go
@@ -478,6 +478,11 @@ func listFiles(dir string) ([]string, error) {
 			continue
 		}
 
+		// Skip temporary backup files some editors create
+		if strings.HasSuffix(file.Name(), "~") {
+			continue
+		}
+
 		if file.IsDir() {
 			children, err := listFiles(filepath.Join(dir, file.Name()))
 			if err != nil {

--- a/cmd/content/push_test.go
+++ b/cmd/content/push_test.go
@@ -142,3 +142,24 @@ func TestListDirsEmptyDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+func TestListFilesIgnoreBackupFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a real file and a ~ temp file
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "index.md"), []byte("content"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "index.md~"), []byte("unsaved content"), 0644))
+
+	result, err := listFiles(tmpDir)
+	require.NoError(t, err)
+
+	var relPaths []string
+	for _, path := range result {
+		relPath, err := filepath.Rel(tmpDir, path)
+		require.NoError(t, err)
+		relPaths = append(relPaths, relPath)
+	}
+
+	// assert: the temp file is not listed
+	assert.Equal(t, []string{"index.md"}, relPaths)
+}


### PR DESCRIPTION
When I run `labctl content push -fw course <course>` and edit the files in intelliJ IDEA, once I save eg. `index.md` I get this error:

> labctl: Couldn't list local content files: open <path>/index.md~: no such file or directory.

The issue seems to be that intelliJ IDEA (and other editors) create a temp backup file of edited but not saved files, they have the suffix `~`. The file watcher picks up on them, but when they are saved the temp file is removed.

The fix here is to just ignore all files ending in `~`. Claude suggested to ignore a bunch of other file names, such as starting with `#` or ending in `.swp` but I didn't encounter this issue and I'm not sure if it is real, so I focused on `~` only.

I haven't run the fixed cli locally, how can I do that? I added a test to confirm that `~` files are not returned from `listFiles`, please let me know if there's any other steps needed to validate this PR before merging. 