### PR TITLE
Add native Windows binary support for labctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.swo
 
 labctl
+labctl.exe
 
 dist/

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ build-dev-darwin-arm64:
 		-ldflags="-X 'main.version=dev' -X 'main.commit=${GIT_COMMIT}' -X 'main.date=${UTC_NOW}'" \
 		-o labctl
 
+.PHONY: build-dev-windows-amd64
+build-dev-windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build \
+		-ldflags="-X 'main.version=dev' -X 'main.commit=${GIT_COMMIT}' -X 'main.date=${UTC_NOW}'" \
+		-o labctl.exe
+
 .PHONY: release
 release:
 	goreleaser --clean

--- a/cmd/content/push_test.go
+++ b/cmd/content/push_test.go
@@ -51,7 +51,7 @@ func TestListFiles(t *testing.T) {
 	for _, path := range result {
 		relPath, err := filepath.Rel(tmpDir, path)
 		require.NoError(t, err)
-		relPaths = append(relPaths, relPath)
+		relPaths = append(relPaths, filepath.ToSlash(relPath))
 	}
 
 	// Expected files (only non-.git files)
@@ -105,7 +105,7 @@ func TestListDirs(t *testing.T) {
 	for _, path := range result {
 		relPath, err := filepath.Rel(tmpDir, path)
 		require.NoError(t, err)
-		relPaths = append(relPaths, relPath)
+		relPaths = append(relPaths, filepath.ToSlash(relPath))
 	}
 
 	// Expected directories (only non-.git directories)
@@ -157,7 +157,7 @@ func TestListFilesIgnoreBackupFiles(t *testing.T) {
 	for _, path := range result {
 		relPath, err := filepath.Rel(tmpDir, path)
 		require.NoError(t, err)
-		relPaths = append(relPaths, relPath)
+		relPaths = append(relPaths, filepath.ToSlash(relPath))
 	}
 
 	// assert: the temp file is not listed

--- a/cmd/ide/ide.go
+++ b/cmd/ide/ide.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/iximiuz/labctl/internal/completion"
 	"github.com/iximiuz/labctl/internal/labcli"
@@ -314,7 +316,7 @@ func runIDE(ctx context.Context, cli labcli.CLI, opts *options) error {
 	if err := codeCmd.Start(); err != nil {
 		return fmt.Errorf("couldn't open %s: %w", opts.ide, err)
 	}
-	cli.PrintAux("%s launched.\n", strings.Title(opts.ide))
+	cli.PrintAux("%s launched.\n", cases.Title(language.Und).String(opts.ide))
 
 	cli.PrintAux("\n# If the IDE fails to connect, add the following to your ~/.ssh/config:\n")
 	cli.PrintAux("Host localhost 127.0.0.1 ::1\n")

--- a/cmd/ide/ide.go
+++ b/cmd/ide/ide.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -78,12 +77,12 @@ func parseRepoSpec(spec string) (repoSpec, error) {
 // cloneTarget returns the absolute path where the repo should be cloned.
 func (r repoSpec) cloneTarget(baseDir string) string {
 	if r.cloneDir != "" {
-		if filepath.IsAbs(r.cloneDir) {
+		if remotePathIsAbs(r.cloneDir) {
 			return r.cloneDir
 		}
-		return filepath.Join(baseDir, r.cloneDir)
+		return remotePathJoin(baseDir, r.cloneDir)
 	}
-	return filepath.Join(baseDir, repoBaseName(r.url))
+	return remotePathJoin(baseDir, repoBaseName(r.url))
 }
 
 type options struct {
@@ -261,19 +260,14 @@ func runIDE(ctx context.Context, cli labcli.CLI, opts *options) error {
 	workDir := opts.workDir
 	switch {
 	case workDir != "":
-		if !filepath.IsAbs(workDir) {
-			workDir = filepath.Join(homeDir, workDir)
+		if !remotePathIsAbs(workDir) {
+			workDir = remotePathJoin(homeDir, workDir)
 		}
 	case len(repos) == 1:
 		// Default to the single repo's clone folder.
 		workDir = repos[0].cloneTarget(homeDir)
 	default:
 		workDir = homeDir
-	}
-
-	// Normalize remote Linux paths on Windows.
-	if workDir != "" && !filepath.IsAbs(workDir) {
-		workDir = path.Join(homeDir, workDir)
 	}
 
 	// Workaround: SSH into the playground first - otherwise, the IDE may fail to connect.
@@ -358,7 +352,7 @@ func cloneRepos(ctx context.Context, cli labcli.CLI, opts *options, repos []repo
 
 			cloneCmd := fmt.Sprintf(
 				"mkdir -p %s && GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git clone %s %s",
-				filepath.Dir(target), r.url, target)
+				path.Dir(target), r.url, target)
 
 			var err error
 			if opts.forwardAgent {
@@ -429,6 +423,17 @@ func repoBaseName(repo string) string {
 		name = name[i+1:]
 	}
 	return name
+}
+
+func remotePathIsAbs(p string) bool {
+	return strings.HasPrefix(p, "/")
+}
+
+func remotePathJoin(baseDir, p string) string {
+	if remotePathIsAbs(p) {
+		return p
+	}
+	return path.Join(baseDir, p)
 }
 
 func userHomeDir(user string) string {

--- a/cmd/ide/ide.go
+++ b/cmd/ide/ide.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -269,6 +271,11 @@ func runIDE(ctx context.Context, cli labcli.CLI, opts *options) error {
 		workDir = homeDir
 	}
 
+	// Normalize remote Linux paths on Windows.
+	if workDir != "" && !filepath.IsAbs(workDir) {
+		workDir = path.Join(homeDir, workDir)
+	}
+
 	// Workaround: SSH into the playground first - otherwise, the IDE may fail to connect.
 	warmup := exec.CommandContext(ctx, "ssh",
 		"-o", "UserKnownHostsFile=/dev/null",
@@ -276,7 +283,9 @@ func runIDE(ctx context.Context, cli labcli.CLI, opts *options) error {
 		"-o", "IdentitiesOnly=yes",
 		"-o", "PreferredAuthentications=publickey",
 		"-i", cli.Config().SSHIdentityFile,
-		fmt.Sprintf("ssh://%s@%s:%s", opts.user, localHost, localPort),
+		"-p", localPort,
+		fmt.Sprintf("%s@%s", opts.user, localHost),
+		"true",
 	)
 	warmup.Run()
 
@@ -301,10 +310,17 @@ func runIDE(ctx context.Context, cli labcli.CLI, opts *options) error {
 	cli.PrintAux("Opening %s...\n", opts.ide)
 	cli.PrintAux("Running: %s --folder-uri %s\n", opts.ide, folderURI)
 
-	cmd := exec.CommandContext(ctx, opts.ide, "--folder-uri", folderURI)
-	if err := cmd.Run(); err != nil {
+	codeCmd := exec.CommandContext(ctx, opts.ide, "--folder-uri", folderURI)
+	if runtime.GOOS == "windows" {
+		codeCmd = exec.CommandContext(ctx, "cmd", "/C", opts.ide, "--folder-uri", folderURI)
+	}
+	codeCmd.Stdout = os.Stdout
+	codeCmd.Stderr = os.Stderr
+	codeCmd.Stdin = os.Stdin
+	if err := codeCmd.Start(); err != nil {
 		return fmt.Errorf("couldn't open %s: %w", opts.ide, err)
 	}
+	cli.PrintAux("%s launched.\n", strings.Title(opts.ide))
 
 	cli.PrintAux("\n# If the IDE fails to connect, add the following to your ~/.ssh/config:\n")
 	cli.PrintAux("Host localhost 127.0.0.1 ::1\n")
@@ -389,11 +405,12 @@ func doRunRemoteCommand(ctx context.Context, identityFile, user, host, port, com
 		"-o", "IdentitiesOnly=yes",
 		"-o", "PreferredAuthentications=publickey",
 		"-i", identityFile,
+		"-p", port,
 	}
 	if forwardAgent {
 		args = append(args, "-o", "ForwardAgent=yes")
 	}
-	args = append(args, fmt.Sprintf("ssh://%s@%s:%s", user, host, port), command)
+	args = append(args, fmt.Sprintf("%s@%s", user, host), command)
 
 	cmd := exec.CommandContext(ctx, "ssh", args...)
 	out, err := cmd.CombinedOutput()

--- a/cmd/ide/ide_test.go
+++ b/cmd/ide/ide_test.go
@@ -1,0 +1,36 @@
+package ide
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemotePathIsAbs(t *testing.T) {
+	assert.True(t, remotePathIsAbs("/home/laborant"))
+	assert.True(t, remotePathIsAbs("/root"))
+	assert.False(t, remotePathIsAbs("home/laborant"))
+	assert.False(t, remotePathIsAbs("./home/laborant"))
+}
+
+func TestRemotePathJoin(t *testing.T) {
+	assert.Equal(t, "/home/laborant/projects", remotePathJoin("/home/laborant", "projects"))
+	assert.Equal(t, "/home/laborant", remotePathJoin("/home/laborant", "/home/laborant"))
+	assert.Equal(t, "/home/laborant/home/laborant", remotePathJoin("/home/laborant", "home/laborant"))
+}
+
+func TestRepoSpecCloneTarget(t *testing.T) {
+	baseDir := "/home/laborant"
+
+	repo := repoSpec{url: "https://github.com/foo/bar"}
+	assert.Equal(t, "/home/laborant/bar", repo.cloneTarget(baseDir))
+
+	repo = repoSpec{url: "git@github.com:foo/bar", cloneDir: "projects"}
+	assert.Equal(t, "/home/laborant/projects", repo.cloneTarget(baseDir))
+
+	repo = repoSpec{url: "git@github.com:foo/bar", cloneDir: "/tmp/project"}
+	assert.Equal(t, "/tmp/project", repo.cloneTarget(baseDir))
+
+	repo = repoSpec{url: "https://github.com/foo/bar", cloneDir: "home/laborant"}
+	assert.Equal(t, "/home/laborant/home/laborant", repo.cloneTarget(baseDir))
+}

--- a/internal/ssh/session_windows.go
+++ b/internal/ssh/session_windows.go
@@ -1,0 +1,142 @@
+//go:build windows
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/iximiuz/labctl/internal/labcli"
+	"golang.org/x/crypto/ssh"
+)
+
+const defaultTermEnv = "xterm-256color"
+
+type Session struct {
+	client *ssh.Client
+}
+
+func NewSession(
+	conn net.Conn,
+	user string,
+	sshKeyPath string,
+	forwardAgent bool,
+) (*Session, error) {
+	var authMethods []ssh.AuthMethod
+
+	privateKey, err := readPrivateKey(sshKeyPath)
+	if err != nil {
+		slog.Debug("Failed to read SSH private key", "error", err)
+	} else {
+		keySigner, err := ssh.ParsePrivateKey([]byte(privateKey))
+		if err != nil {
+			slog.Debug("Failed to parse SSH private key", "error", err)
+		} else {
+			authMethods = append(authMethods, ssh.PublicKeys(keySigner))
+		}
+	}
+
+	if forwardAgent {
+		slog.Warn("SSH agent forwarding is not supported on Windows")
+	}
+
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, conn.RemoteAddr().String(), &ssh.ClientConfig{
+		User:              user,
+		Auth:              authMethods,
+		HostKeyCallback:   ssh.InsecureIgnoreHostKey(),
+		HostKeyAlgorithms: []string{ssh.KeyAlgoED25519},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create SSH client connection: %w", err)
+	}
+
+	client := ssh.NewClient(sshConn, chans, reqs)
+	return &Session{client: client}, nil
+}
+
+func (s *Session) Run(ctx context.Context, streams labcli.Streams, cmd string) error {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("create SSH session: %w", err)
+	}
+	defer sess.Close()
+
+	if streams.InputStream().IsTerminal() {
+		if err := streams.InputStream().SetRawTerminal(); err != nil {
+			slog.Warn("Could not enable raw terminal mode", "error", err.Error())
+		} else {
+			defer streams.InputStream().RestoreTerminal()
+
+			height, width := streams.OutputStream().GetTtySize()
+			if height == 0 {
+				height = 40
+			}
+			if width == 0 {
+				width = 80
+			}
+
+			if err := sess.RequestPty(defaultTermEnv, int(height), int(width), ssh.TerminalModes{
+				ssh.TTY_OP_ISPEED: 14400,
+				ssh.TTY_OP_OSPEED: 14400,
+			}); err != nil {
+				return fmt.Errorf("request PTY: %w", err)
+			}
+		}
+	}
+
+	sess.Stdout = streams.OutputStream()
+	sess.Stderr = streams.ErrorStream()
+
+	var closeStdin sync.Once
+	stdin, err := sess.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("get stdin pipe: %w", err)
+	}
+
+	go func() {
+		defer closeStdin.Do(func() {
+			stdin.Close()
+		})
+
+		io.Copy(stdin, streams.InputStream())
+	}()
+
+	cmdC := make(chan error, 1)
+	go func() {
+		defer close(cmdC)
+
+		var err error
+		if cmd == "" {
+			err = sess.Shell()
+			if err == nil {
+				err = sess.Wait()
+			}
+		} else {
+			err = sess.Run(cmd)
+		}
+
+		if err != nil && err != io.EOF {
+			cmdC <- err
+		}
+	}()
+
+	select {
+	case err := <-cmdC:
+		return err
+	case <-ctx.Done():
+		return errors.New("session forcibly closed; the remote process may still be running")
+	}
+}
+
+func (s *Session) Close() error {
+	return s.client.Close()
+}
+
+func (s *Session) Wait() error {
+	return s.client.Wait()
+}


### PR DESCRIPTION
## PR Description

### Summary
This PR adds native Windows support for `labctl` by introducing a Windows build target and Windows-specific runtime handling.

### What changed
- Added `build-dev-windows-amd64` target to Makefile
- Added labctl.exe to .gitignore
- Implemented Windows-specific SSH session handling in session_windows.go
- Added Windows-aware IDE launch flow in ide.go
- Updated IDE launch output to use Unicode-safe title casing
- Added/expanded tests around remote path handling in ide_test.go

### Why
Windows users currently do not have a native labctl.exe binary build available, which makes installation and usage harder. This PR addresses that gap and prepares the repo for a first-class Windows build workflow.

### Fixes
- Fixes https://github.com/iximiuz/labctl/issues/101

### Testing
- `go test d:.`
- `make build-dev-windows-amd64`

> This PR is focused on enabling native Windows binary support and ensuring the repo can produce labctl.exe cleanly.