### PR TITLE
Restarting playgrounds using title when provided instead of playground id

### DIFF
--- a/api/plays.go
+++ b/api/plays.go
@@ -304,10 +304,10 @@ type ListPlaysQueryParams struct {
 	Persistent bool `json:"persistent,omitempty" yaml:"persistent,omitempty"`
 }
 
-func (c *Client) ListPlays(ctx context.Context, listQueryParams *ListPlaysQueryParams) ([]*Play, error) {
+func (c *Client) ListPlays(ctx context.Context, listPlaysQueryParams ListPlaysQueryParams) ([]*Play, error) {
 	var plays []*Play
 	query := url.Values{}
-	if listQueryParams.Persistent {
+	if listPlaysQueryParams.Persistent {
 		query.Add("persistent", "true")
 	}
 	return plays, c.GetInto(ctx, "/plays", query, nil, &plays)

--- a/api/plays.go
+++ b/api/plays.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -55,6 +56,7 @@ type PlayStatus struct {
 type Play struct {
 	ID string `json:"id" yaml:"id"`
 
+	Title       string `json:"title" yaml:"title"`
 	CreatedAt   string `json:"createdAt" yaml:"createdAt"`
 	UpdatedAt   string `json:"updatedAt" yaml:"updatedAt"`
 	LastStateAt string `json:"lastStateAt" yaml:"lastStateAt"`
@@ -298,9 +300,17 @@ func (c *Client) GetPlay(ctx context.Context, id string) (*Play, error) {
 	return &p, c.GetInto(ctx, "/plays/"+id, nil, nil, &p)
 }
 
-func (c *Client) ListPlays(ctx context.Context) ([]*Play, error) {
+type ListPlaysQueryParams struct {
+	Persistent bool `json:"persistent,omitempty" yaml:"persistent,omitempty"`
+}
+
+func (c *Client) ListPlays(ctx context.Context, listQueryParams *ListPlaysQueryParams) ([]*Play, error) {
 	var plays []*Play
-	return plays, c.GetInto(ctx, "/plays", nil, nil, &plays)
+	query := url.Values{}
+	if listQueryParams.Persistent {
+		query.Add("persistent", "true")
+	}
+	return plays, c.GetInto(ctx, "/plays", query, nil, &plays)
 }
 
 func (c *Client) StopPlay(ctx context.Context, id string) (*Play, error) {

--- a/cmd/challenge/list.go
+++ b/cmd/challenge/list.go
@@ -44,7 +44,7 @@ func newListCommand(cli labcli.CLI) *cobra.Command {
 }
 
 func runListChallenges(ctx context.Context, cli labcli.CLI, opts *listOptions) error {
-	plays, err := cli.Client().ListPlays(ctx)
+	plays, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{})
 	if err != nil {
 		return fmt.Errorf("cannot list plays: %w", err)
 	}

--- a/cmd/challenge/list.go
+++ b/cmd/challenge/list.go
@@ -44,7 +44,7 @@ func newListCommand(cli labcli.CLI) *cobra.Command {
 }
 
 func runListChallenges(ctx context.Context, cli labcli.CLI, opts *listOptions) error {
-	plays, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{})
+	plays, err := cli.Client().ListPlays(ctx, api.ListPlaysQueryParams{})
 	if err != nil {
 		return fmt.Errorf("cannot list plays: %w", err)
 	}

--- a/cmd/playground/list.go
+++ b/cmd/playground/list.go
@@ -122,7 +122,8 @@ func newListPrinter(w io.Writer, output string) listPrinter {
 	case "table":
 		header := []string{
 			"PLAYGROUND ID",
-			"NAME",
+			"PLAYGROUND NAME",
+			"CUSTOM TITLE",
 			"CREATED",
 			"STATUS",
 			"LINK",
@@ -137,6 +138,7 @@ func newListPrinter(w io.Writer, output string) listPrinter {
 			return []string{
 				play.ID,
 				play.Playground.Name,
+				play.Title,
 				humanize.Time(safeParseTime(play.CreatedAt)),
 				playStatus(play),
 				link,

--- a/cmd/playground/list.go
+++ b/cmd/playground/list.go
@@ -83,7 +83,7 @@ func runListPlays(ctx context.Context, cli labcli.CLI, opts *listOptions) error 
 		return err
 	}
 
-	plays, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{})
+	plays, err := cli.Client().ListPlays(ctx, api.ListPlaysQueryParams{})
 	if err != nil {
 		return fmt.Errorf("couldn't list playgrounds: %w", err)
 	}
@@ -123,7 +123,7 @@ func newListPrinter(w io.Writer, output string) listPrinter {
 		header := []string{
 			"PLAYGROUND ID",
 			"PLAYGROUND NAME",
-			"CUSTOM TITLE",
+			"TITLE",
 			"CREATED",
 			"STATUS",
 			"LINK",

--- a/cmd/playground/list.go
+++ b/cmd/playground/list.go
@@ -83,7 +83,7 @@ func runListPlays(ctx context.Context, cli labcli.CLI, opts *listOptions) error 
 		return err
 	}
 
-	plays, err := cli.Client().ListPlays(ctx)
+	plays, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{})
 	if err != nil {
 		return fmt.Errorf("couldn't list playgrounds: %w", err)
 	}

--- a/cmd/playground/restart.go
+++ b/cmd/playground/restart.go
@@ -22,6 +22,7 @@ const restartCommandTimeout = 5 * time.Minute
 
 type restartOptions struct {
 	playID string
+	title  string
 
 	machine string
 	user    string
@@ -41,9 +42,8 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 	var opts restartOptions
 
 	cmd := &cobra.Command{
-		Use:               "restart [flags] <playground-id>",
+		Use:               "restart [flags]",
 		Short:             `Restart a stopped playground session, resuming its state`,
-		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.StoppedPlays(cli),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.SetQuiet(opts.quiet)
@@ -56,13 +56,30 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 				return labcli.NewStatusError(1, "can't use --ide and --ssh flags at the same time")
 			}
 
-			opts.playID = args[0]
+			if len(args) == 0 && opts.title == "" {
+				return labcli.NewStatusError(1, "either specify an argument playID or the title of playground using `--title`")
+			}
+
+			if len(args) == 1 {
+				opts.playID = args[0]
+			}
+
+			if len(args) > 1 {
+				return labcli.NewStatusError(1, "only 1 playgroundId is supported at a time, found more")
+			}
 
 			return labcli.WrapStatusError(runRestartPlayground(cmd.Context(), cli, &opts))
 		},
 	}
 
 	flags := cmd.Flags()
+
+	flags.StringVar(
+		&opts.title,
+		"title",
+		"",
+		`title of the playground that needs to be restarted`,
+	)
 
 	flags.StringVarP(
 		&opts.machine,
@@ -121,6 +138,23 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 }
 
 func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOptions) error {
+	if opts.title != "" {
+		cli.PrintAux("Searching for a playground with title: %s\n", opts.title)
+		playgroundsList, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{Persistent: true})
+		if err != nil {
+			return fmt.Errorf("couldn't get a list of playgrounds: %w", err)
+		}
+		for _, pgItem := range playgroundsList {
+			if pgItem.Title == opts.title {
+				opts.playID = pgItem.ID
+			}
+		}
+
+		if opts.playID == "" {
+			return fmt.Errorf("unable to find a playground with mentioned title")
+		}
+	}
+
 	cli.PrintAux("Restarting playground %s...\n", opts.playID)
 
 	play, err := cli.Client().RestartPlay(ctx, opts.playID)

--- a/cmd/playground/restart.go
+++ b/cmd/playground/restart.go
@@ -49,6 +49,7 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "restart [flags] <playground-id|title>",
 		Short:             `Restart a stopped playground session, resuming its state`,
+		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.StoppedPlays(cli),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.SetQuiet(opts.quiet)

--- a/cmd/playground/restart.go
+++ b/cmd/playground/restart.go
@@ -140,7 +140,7 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOptions) error {
 	if opts.title != "" {
 		cli.PrintAux("Searching for a playground with title: %s\n", opts.title)
-		playgroundsList, err := cli.Client().ListPlays(ctx, &api.ListPlaysQueryParams{Persistent: true})
+		playgroundsList, err := cli.Client().ListPlays(ctx, api.ListPlaysQueryParams{Persistent: true})
 		if err != nil {
 			return fmt.Errorf("couldn't get a list of playgrounds: %w", err)
 		}

--- a/cmd/playground/restart.go
+++ b/cmd/playground/restart.go
@@ -2,8 +2,10 @@ package playground
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -21,9 +23,7 @@ import (
 const restartCommandTimeout = 5 * time.Minute
 
 type restartOptions struct {
-	playID string
-	title  string
-
+	playId  string
 	machine string
 	user    string
 
@@ -38,11 +38,16 @@ type restartOptions struct {
 	quiet bool
 }
 
+var (
+	// can be a playID or a title of the playground
+	playgroundIdentifier string
+)
+
 func newRestartCommand(cli labcli.CLI) *cobra.Command {
 	var opts restartOptions
 
 	cmd := &cobra.Command{
-		Use:               "restart [flags]",
+		Use:               "restart [flags] <playground-id|title>",
 		Short:             `Restart a stopped playground session, resuming its state`,
 		ValidArgsFunction: completion.StoppedPlays(cli),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,30 +61,12 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 				return labcli.NewStatusError(1, "can't use --ide and --ssh flags at the same time")
 			}
 
-			if len(args) == 0 && opts.title == "" {
-				return labcli.NewStatusError(1, "either specify an argument playID or the title of playground using `--title`")
-			}
-
-			if len(args) == 1 {
-				opts.playID = args[0]
-			}
-
-			if len(args) > 1 {
-				return labcli.NewStatusError(1, "only 1 playgroundId is supported at a time, found more")
-			}
-
-			return labcli.WrapStatusError(runRestartPlayground(cmd.Context(), cli, &opts))
+			playgroundIdentifier = args[0]
+			return labcli.WrapStatusError(runRestartPlayground(cmd.Context(), cli, &opts, playgroundIdentifier))
 		},
 	}
 
 	flags := cmd.Flags()
-
-	flags.StringVar(
-		&opts.title,
-		"title",
-		"",
-		`title of the playground that needs to be restarted`,
-	)
 
 	flags.StringVarP(
 		&opts.machine,
@@ -137,27 +124,8 @@ func newRestartCommand(cli labcli.CLI) *cobra.Command {
 	return cmd
 }
 
-func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOptions) error {
-	if opts.title != "" {
-		cli.PrintAux("Searching for a playground with title: %s\n", opts.title)
-		playgroundsList, err := cli.Client().ListPlays(ctx, api.ListPlaysQueryParams{Persistent: true})
-		if err != nil {
-			return fmt.Errorf("couldn't get a list of playgrounds: %w", err)
-		}
-		for _, pgItem := range playgroundsList {
-			if pgItem.Title == opts.title {
-				opts.playID = pgItem.ID
-			}
-		}
-
-		if opts.playID == "" {
-			return fmt.Errorf("unable to find a playground with mentioned title")
-		}
-	}
-
-	cli.PrintAux("Restarting playground %s...\n", opts.playID)
-
-	play, err := cli.Client().RestartPlay(ctx, opts.playID)
+func restartWithPlaygroundId(ctx context.Context, cli labcli.CLI, opts *restartOptions) error {
+	play, err := cli.Client().RestartPlay(ctx, opts.playId)
 	if err != nil {
 		return fmt.Errorf("couldn't restart the playground: %w", err)
 	}
@@ -171,7 +139,7 @@ func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOpti
 	defer cancel()
 
 	for ctx.Err() == nil {
-		if play, err := cli.Client().GetPlay(ctx, opts.playID); err == nil {
+		if play, err := cli.Client().GetPlay(ctx, opts.playId); err == nil {
 			if play.StateIs(api.StateRunning) {
 				s.FinalMSG = "Waiting for playground to restart... Done.\n"
 				s.Stop()
@@ -244,4 +212,58 @@ func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOpti
 	}
 
 	return nil
+}
+
+func isItPlaygroundIDCheck(id string) bool {
+	if len(id) != 24 {
+		return false
+	}
+	// check if each charachter within the string falls in the hex range
+	for _, c := range id {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func runRestartPlayground(ctx context.Context, cli labcli.CLI, opts *restartOptions, playgroundIdentifier string) error {
+	cli.PrintAux("Restarting playground %s...\n", playgroundIdentifier)
+
+	// if the provided identifier is a confirmed playgroundID restart it immediately
+	if isItPlaygroundIDCheck(playgroundIdentifier) {
+		opts.playId = playgroundIdentifier
+		return restartWithPlaygroundId(ctx, cli, opts)
+	}
+
+	// if identifier is not a playgroundID search for playgrounds with matching titles
+	// and if found one restart it.
+	var matchingPlaygrounds []api.Play
+
+	cli.PrintAux("Searching for a playground with title: %s\n", playgroundIdentifier)
+	playgroundsList, err := cli.Client().ListPlays(ctx, api.ListPlaysQueryParams{Persistent: true})
+	if err != nil {
+		return fmt.Errorf("couldn't get a list of playgrounds: %w", err)
+	}
+	for _, pgItem := range playgroundsList {
+		if pgItem.Title == playgroundIdentifier {
+			matchingPlaygrounds = []api.Play{*pgItem}
+			break
+		}
+
+		if strings.HasPrefix(pgItem.Title, playgroundIdentifier) {
+			matchingPlaygrounds = append(matchingPlaygrounds, *pgItem)
+		}
+	}
+
+	if len(matchingPlaygrounds) == 0 {
+		return errors.New("unable to find a playground with provided title")
+	}
+
+	if len(matchingPlaygrounds) > 1 {
+		return errors.New("unambigious title, please use the full title of a playground or a longer prefix")
+	}
+
+	opts.playId = matchingPlaygrounds[0].ID
+	return restartWithPlaygroundId(ctx, cli, opts)
 }

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -50,7 +50,7 @@ func plays(cli labcli.CLI, filter func(*api.Play) bool) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
+		plays, err := cli.Client().ListPlays(cmd.Context(), api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -187,7 +187,7 @@ func StartedChallengeNames(cli labcli.CLI) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
+		plays, err := cli.Client().ListPlays(cmd.Context(), api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -244,7 +244,7 @@ func StartedTutorialNames(cli labcli.CLI) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
+		plays, err := cli.Client().ListPlays(cmd.Context(), api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -320,7 +320,7 @@ func StartedCourseArgs(cli labcli.CLI) CompletionFunc {
 		switch len(args) {
 		case 0:
 			// Complete course names that have active play sessions.
-			plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
+			plays, err := cli.Client().ListPlays(cmd.Context(), api.ListPlaysQueryParams{})
 			if err != nil {
 				return nil, noFileComp
 			}

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -50,7 +50,7 @@ func plays(cli labcli.CLI, filter func(*api.Play) bool) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context())
+		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -187,7 +187,7 @@ func StartedChallengeNames(cli labcli.CLI) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context())
+		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -244,7 +244,7 @@ func StartedTutorialNames(cli labcli.CLI) CompletionFunc {
 			return nil, noFileComp
 		}
 
-		plays, err := cli.Client().ListPlays(cmd.Context())
+		plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
 		if err != nil {
 			return nil, noFileComp
 		}
@@ -320,7 +320,7 @@ func StartedCourseArgs(cli labcli.CLI) CompletionFunc {
 		switch len(args) {
 		case 0:
 			// Complete course names that have active play sessions.
-			plays, err := cli.Client().ListPlays(cmd.Context())
+			plays, err := cli.Client().ListPlays(cmd.Context(), &api.ListPlaysQueryParams{})
 			if err != nil {
 				return nil, noFileComp
 			}


### PR DESCRIPTION
labctl allows a user to restart a persistent/stopped playground using the `labctl restart` command but it requires the user to enter playground id to use it. I find it a bit inconvenient. 

This PR 

* changes the `labctl p list` command so that it displays the title set on a playground with it
* adds the capability for a user to restart a playground using the `title` if already set on a playground
