### PR TITLE
feat: allowing user to set title along with the start command

### DIFF
--- a/api/plays.go
+++ b/api/plays.go
@@ -364,7 +364,7 @@ func (c *Client) ListPlays(ctx context.Context, listPlaysQueryParams ListPlaysQu
 	return plays, c.GetInto(ctx, "/plays", query, nil, &plays)
 }
 
-func (c *Client) SetTitle(ctx context.Context, id string, title string) (*Play, error) {
+func (c *Client) SetPlayTitle(ctx context.Context, id string, title string) (*Play, error) {
 	body, err := toJSONBody(map[string]any{"action": "set_title", "title": title})
 	if err != nil {
 		return nil, err

--- a/api/plays.go
+++ b/api/plays.go
@@ -364,6 +364,16 @@ func (c *Client) ListPlays(ctx context.Context, listPlaysQueryParams ListPlaysQu
 	return plays, c.GetInto(ctx, "/plays", query, nil, &plays)
 }
 
+func (c *Client) SetTitle(ctx context.Context, id string, title string) (*Play, error) {
+	body, err := toJSONBody(map[string]any{"action": "set_title", "title": title})
+	if err != nil {
+		return nil, err
+	}
+
+	var p Play
+	return &p, c.PostInto(ctx, "/plays/"+id+"/actions", nil, nil, body, &p)
+}
+
 func (c *Client) StopPlay(ctx context.Context, id string) (*Play, error) {
 	body, err := toJSONBody(map[string]any{"action": "stop"})
 	if err != nil {

--- a/cmd/playground/start.go
+++ b/cmd/playground/start.go
@@ -257,17 +257,18 @@ func runStartPlayground(ctx context.Context, cli labcli.CLI, opts *startOptions)
 		return err
 	}
 
+	cli.PrintAux("New %s playground started with ID %s\n", opts.playground, play.ID)
+
 	// set a title, this should be a non-failure causing request by default
 	if opts.title != "" {
-		play, err = cli.Client().SetTitle(ctx, play.ID, opts.title)
+		var playResponse *api.Play
+		playResponse, err = cli.Client().SetTitle(ctx, play.ID, opts.title)
 		if err != nil {
-			cli.PrintAux(fmt.Sprintf("Unable to set title: %s, exception: %s", opts.title, err.Error()))
+			cli.PrintAux(fmt.Sprintf("Unable to set title: %s, exception: %s\n", opts.title, err.Error()))
 		} else {
-			cli.PrintAux(fmt.Sprintf("Playground created id: %s, setting title: %s", play.ID, opts.title))
+			cli.PrintAux(fmt.Sprintf("Title set: %s\n", playResponse.Title))
 		}
 	}
-
-	cli.PrintAux("New %s playground started with ID %s\n", opts.playground, play.ID)
 
 	if opts.open {
 		browser.OpenWithFallbackMessage(cli, play.PageURL)

--- a/cmd/playground/start.go
+++ b/cmd/playground/start.go
@@ -26,6 +26,7 @@ type startOptions struct {
 	playground string
 	machine    string
 	user       string
+	title      string
 
 	file string
 	open bool
@@ -109,6 +110,12 @@ func newStartCommand(cli labcli.CLI) *cobra.Command {
 		"u",
 		"",
 		`SSH user (default: the machine's default login user)`,
+	)
+	flags.StringVar(
+		&opts.title,
+		"title",
+		"",
+		`Title string which once set can be used to restart, stop and ssh into`,
 	)
 	flags.BoolVarP(
 		&opts.open,
@@ -248,6 +255,16 @@ func runStartPlayground(ctx context.Context, cli labcli.CLI, opts *startOptions)
 	}
 	if opts.user, err = play.ResolveUser(opts.machine, opts.user); err != nil {
 		return err
+	}
+
+	// set a title, this should be a non-failure causing request by default
+	if opts.title != "" {
+		play, err = cli.Client().SetTitle(ctx, play.ID, opts.title)
+		if err != nil {
+			cli.PrintAux(fmt.Sprintf("Unable to set title: %s, exception: %s", opts.title, err.Error()))
+		} else {
+			cli.PrintAux(fmt.Sprintf("Playground created id: %s, setting title: %s", play.ID, opts.title))
+		}
 	}
 
 	cli.PrintAux("New %s playground started with ID %s\n", opts.playground, play.ID)

--- a/cmd/playground/start.go
+++ b/cmd/playground/start.go
@@ -262,7 +262,7 @@ func runStartPlayground(ctx context.Context, cli labcli.CLI, opts *startOptions)
 	// set a title, this should be a non-failure causing request by default
 	if opts.title != "" {
 		var playResponse *api.Play
-		playResponse, err = cli.Client().SetTitle(ctx, play.ID, opts.title)
+		playResponse, err = cli.Client().SetPlayTitle(ctx, play.ID, opts.title)
 		if err != nil {
 			cli.PrintAux(fmt.Sprintf("Unable to set title: %s, exception: %s\n", opts.title, err.Error()))
 		} else {


### PR DESCRIPTION
This PR allows a user to provide `--title` argument which when specified its value is used to configure a title for the playground being created. 