### PR TITLE
feat: antigravity ide support

### DIFF
--- a/cmd/ide/ide.go
+++ b/cmd/ide/ide.go
@@ -95,7 +95,7 @@ func NewCommand(cli labcli.CLI) *cobra.Command {
 	var opts options
 
 	cmd := &cobra.Command{
-		Use:   "ide <code|cursor|windsurf|zed> <playground-id>",
+		Use:   "ide <antigravity-ide|code|cursor|windsurf|zed> <playground-id>",
 		Short: `Open a playground in a local IDE`,
 		Long: `Start an SSH proxy to the playground and open it in the specified IDE.
 
@@ -170,6 +170,7 @@ func ideCompletion(cli labcli.CLI) completion.CompletionFunc {
 		switch len(args) {
 		case 0:
 			return []string{
+				ideutil.Antigravity + "\tAntigravity IDE",
 				ideutil.VSCode + "\tVisual Studio Code",
 				ideutil.Cursor + "\tCursor",
 				ideutil.Windsurf + "\tWindsurf",

--- a/internal/ide/ide.go
+++ b/internal/ide/ide.go
@@ -12,14 +12,15 @@ import (
 )
 
 const (
-	VSCode   = "code"
-	Cursor   = "cursor"
-	Windsurf = "windsurf"
-	Zed      = "zed"
+	Antigravity = "antigravity-ide"
+	VSCode      = "code"
+	Cursor      = "cursor"
+	Windsurf    = "windsurf"
+	Zed         = "zed"
 )
 
 // Supported lists the IDE CLI names labctl knows how to open, in display order.
-var Supported = []string{VSCode, Cursor, Windsurf, Zed}
+var Supported = []string{Antigravity, VSCode, Cursor, Windsurf, Zed}
 
 // IsSupported reports whether name is one of the supported IDEs.
 func IsSupported(name string) bool {
@@ -27,7 +28,7 @@ func IsSupported(name string) bool {
 }
 
 // SupportedList returns the supported IDE names as a quoted, comma-separated
-// string for help text and error messages, e.g. `"code", "cursor", "windsurf", "zed"`.
+// string for help text and error messages, e.g. `"antigravity-ide", "code", "cursor", "windsurf", "zed"`.
 func SupportedList() string {
 	quoted := make([]string, len(Supported))
 	for i, s := range Supported {


### PR DESCRIPTION
adds `antigravity-ide` support to `labctl ide <ide>` subcommand